### PR TITLE
Edit Page Fixes

### DIFF
--- a/carr/templates/carr_main/page.html
+++ b/carr/templates/carr_main/page.html
@@ -16,6 +16,14 @@
 	{% endwith %}
 {% endblock %}
 
+{% block subnav %}
+    {% if request.user.is_superuser %}      
+        <li>
+            <a href="/edit{{section.get_absolute_url}}">Edit Page</a>
+        </li>
+    {% endif %}
+{% endblock %}
+
 {% block content %}
    {% if not accessible %}
       This page is not currently accessible. Please complete your current section before moving onto a new section.

--- a/carr/urls.py
+++ b/carr/urls.py
@@ -78,6 +78,8 @@ urlpatterns = patterns(
     (r'^background/(?P<content_to_show>\w+)/$',
      'carr.carr_main.views.background'),
 
+    (r'^pagetree/', include('pagetree.urls')),
+
     # analytics:
     (r'^_stats/', TemplateView.as_view(template_name="stats.html")),
     ('^smoketest/$', include('smoketest.urls')),


### PR DESCRIPTION
backstory: I noticed an image link in the pagetree content was inaccurate this morning when verifying the Django 1.7.6 upgrade. When I went to fix the link, I found that the pagetree edit page was broken. The changes below should fix the edit page and make it more easily accessible.
 
* add pagetree.urls to urls.py to support edit_page.html reverses.
* provide an edit link on each section page so I never have to think about this again.