### PR TITLE
Work around strptime bug

### DIFF
--- a/apache/cdm.wsgi
+++ b/apache/cdm.wsgi
@@ -1,5 +1,8 @@
 import os, sys, site
 
+# http://bugs.python.org/issue7980
+import _strptime
+
 # paths we might need to pick up the project's settings
 sys.path.append('/var/www/carr/carr/')
 

--- a/apache/ssw.wsgi
+++ b/apache/ssw.wsgi
@@ -1,5 +1,8 @@
 import os, sys, site
 
+# http://bugs.python.org/issue7980
+import _strptime
+
 # paths we might need to pick up the project's settings
 sys.path.append('/var/www/carr/carr/')
 

--- a/apache/staging.wsgi
+++ b/apache/staging.wsgi
@@ -1,5 +1,8 @@
 import os, sys, site
 
+# http://bugs.python.org/issue7980
+import _strptime
+
 # paths we might need to pick up the project's settings
 sys.path.append('/var/www/carr/carr/')
 


### PR DESCRIPTION
Sentry error:
  https://sentry.ccnmtl.columbia.edu/sentry-internal/care/group/917/

Apparently datetime.strptime sometimes throws an AttributeError because
it's not thread-safe, see:
  http://bugs.python.org/issue7980

A work-around is to import _strptime at thread start time, because
that's what the first call to datetime.strptime does.