### PR TITLE
Use memcached as caching framework

### DIFF
--- a/carr/settings_production.py
+++ b/carr/settings_production.py
@@ -9,6 +9,13 @@ locals().update(
         STATIC_ROOT=STATIC_ROOT,
     ))
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
+    }
+}
+
 try:
     from local_settings import *  # noqa
 except ImportError:

--- a/carr/settings_shared.py
+++ b/carr/settings_shared.py
@@ -7,8 +7,12 @@ project = 'carr'
 base = os.path.dirname(__file__)
 locals().update(common(project=project, base=base))
 
-# For now turn off caching
-CACHE_BACKEND = 'locmem://'
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'carr',
+    }
+}
 
 MIDDLEWARE_CLASSES += [  # noqa
     'courseaffils.middleware.CourseManagerMiddleware',

--- a/carr/settings_staging.py
+++ b/carr/settings_staging.py
@@ -9,6 +9,13 @@ locals().update(
         INSTALLED_APPS=INSTALLED_APPS,
     ))
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
+    }
+}
+
 try:
     from local_settings import *  # noqa
 except ImportError:


### PR DESCRIPTION
carr makes use of caching when generating scores - see
`carr/quiz/scores.py`. This score generation takes a long time, so I'm
working to reduce this time.