### PR TITLE
Add missing memcache module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,5 +49,6 @@ boto==2.38.0
 python-dateutil==2.4.2
 django-storages-redux==1.3
 django-cacheds3storage==0.1.2
+python-memcached==1.57
 
 ccnmtlsettings==0.1.3


### PR DESCRIPTION
This is missing and causing a 500 error on sentry
https://sentry.ccnmtl.columbia.edu/sentry-internal/care/group/995/