### PR TITLE
media_url redux

### DIFF
--- a/carr/carr_main/templatetags/carr_main_template_tags.py
+++ b/carr/carr_main/templatetags/carr_main_template_tags.py
@@ -1,6 +1,9 @@
 from django import template
-from quiz.templatetags import GetScores
+from django.conf import settings
 
 register = template.Library()
 
-register.tag('get_scores', GetScores.process_tag)
+
+@register.simple_tag
+def media_url():
+    return settings.MEDIA_URL

--- a/carr/templates/activity_bruise_recon/bruise_recon.html
+++ b/carr/templates/activity_bruise_recon/bruise_recon.html
@@ -1,5 +1,7 @@
 {% load smartif %}
 {% load staticfiles %}
+{% load carr_main_template_tags %}
+
 <link href="{% static 'bruise_recon/css/bruise_recon.css' %}" rel="stylesheet" type="text/css" />
 
 <script type="text/javascript" src="{% static 'js/mochikit/MochiKit/MochiKit.js' %}"></script>
@@ -16,7 +18,7 @@
 <div id="case_info_div">
 
 	<div id="bruise_recon_photo_container">
-		<img class="bruise_recon_img" src="{{MEDIA_URL}}uploads/{{block.case.image}}" />
+		<img class="bruise_recon_img" src="{% media_url %}{{block.case.image}}" />
 	</div>
 	
 	<div id="bruise_recon_history_container">

--- a/carr/templates/activity_bruise_recon/student_response.html
+++ b/carr/templates/activity_bruise_recon/student_response.html
@@ -32,7 +32,7 @@
 <div id="case_info_div">
 
 	<div id="bruise_recon_photo_container">
-		<img class="bruise_recon_img" src="{% medial_url %}{{block.case.image}}" />
+		<img class="bruise_recon_img" src="{% media_url %}{{block.case.image}}" />
 	</div>
 	
 	<div id="bruise_recon_history_container">

--- a/carr/templates/activity_bruise_recon/student_response.html
+++ b/carr/templates/activity_bruise_recon/student_response.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
 {% load markup %}
 {% load smartif %}
+{% load carr_main_template_tags %}
+
 {% block title %}{% endblock %}
 
 {% block sidebarleft %}
@@ -30,7 +32,7 @@
 <div id="case_info_div">
 
 	<div id="bruise_recon_photo_container">
-		<img class="bruise_recon_img" src="{{MEDIA_URL}}uploads/{{block.case.image}}" />
+		<img class="bruise_recon_img" src="{% medial_url %}{{block.case.image}}" />
 	</div>
 	
 	<div id="bruise_recon_history_container">

--- a/carr/templates/pageblocks/imageblock.html
+++ b/carr/templates/pageblocks/imageblock.html
@@ -1,0 +1,6 @@
+{% load carr_main_template_tags %}
+{% load markup %}
+<img alt="{{block.alt}}" src="{% media_url %}{{block.image.name}}" />
+<div class="caption">
+{{block.caption|markdown}}
+</div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,4 +50,4 @@ python-dateutil==2.4.2
 django-storages-redux==1.3
 django-cacheds3storage==0.1.2
 
-ccnmtlsettings==0.1.3
+ccnmtlsettings==0.1.5


### PR DESCRIPTION
solve the media_url issue with a template tag rather than a context processor. an old pinned version of pagetree is preventing the required pageblock upgrades to make the context processor work correctly. (pagetree==0.5.9. gah)