### PR TITLE
override pagetree template to remove smartif

### DIFF
--- a/carr/templates/admin/pagetree/section/change_list.html
+++ b/carr/templates/admin/pagetree/section/change_list.html
@@ -1,0 +1,48 @@
+{% extends "admin/base_site.html" %}
+{% load admin_list i18n %}
+
+{% block stylesheet %}css/changelists.css{% endblock %}
+
+{% block bodyclass %}change-list{% endblock %}
+
+{% if not is_popup %}{% block breadcrumbs %}<div class="breadcrumbs"><a href="../../">{% trans "Home" %}</a> &rsaquo; <a href="../">{{ app_label|capfirst }}</a> &rsaquo; {{ cl.opts.verbose_name_plural|capfirst }}</div>{% endblock %}{% endif %}
+
+{% block coltype %}flex{% endblock %}
+
+{% block title %}Site Hierarchy | {% trans "Django Admin" %}{% endblock %}
+
+{% block content_title %}<h1>Site Hierarchy</h1>{% endblock %}
+
+{% block content %}
+
+<div id="content-main">
+{% block object-tools %}
+{% endblock %}
+
+   {% with cl.result_list.0.hierarchy.get_root as root %}
+	<div class="module{% if cl.has_filters %} filtered{% endif %}" id="changelist">
+	   <br />
+		{% block result_list %}
+		   <ul>
+		   {% for s in root.get_descendents %}
+					<li class="menu">
+					   {% ifnotequal s.id section.id %}
+					      <a href="../section/{{s.id}}">{{s.label}}</a>
+					   {%else%}
+					      <b>{{s.label}}</b>
+					   {% endifnotequal %}
+
+						{% with s.get_children as has_children %}
+							{% if has_children %}<ul>{% endif %}
+							{% if not has_children and s.is_last_child %}</ul>{% endif %}
+						{% endwith %}
+					</li>
+			{% endfor %}
+			</ul>
+		{% endblock %}
+	</div>
+	
+	{% endwith %}
+	
+</div>
+{% endblock %}


### PR DESCRIPTION
the ancient pagetree version that carr still uses has one admin template
that tries to load `smartif`, which is no longer used or necessary.

Pulled that template into the codebase to override the `{% load %}`.