### PR TITLE
use dummy cache for unit tests

### DIFF
--- a/carr/settings_shared.py
+++ b/carr/settings_shared.py
@@ -2,6 +2,7 @@
 # Django settings for carr project.
 import os.path
 import re
+import sys
 from datetime import timedelta
 
 from ccnmtlsettings.shared import common
@@ -15,6 +16,14 @@ CACHES = {
         'LOCATION': 'carr',
     }
 }
+if 'test' in sys.argv or 'jenkins' in sys.argv:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+            'LOCATION': 'carr',
+        }
+    }
+
 
 MIDDLEWARE_CLASSES += [  # noqa
     'courseaffils.middleware.CourseManagerMiddleware',


### PR DESCRIPTION
on one of my machines, the tests consistently fail with:

```
./manage.py jenkins --pep8-exclude=migrations --enable-coverage --coverage-rcfile=.coveragerc
Creating test database for alias 'default'...
......................................F...........................................
======================================================================
FAIL: test_question_and_quiz_keys (carr.quiz.tests.test_scores.TestHelpers)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ctlarcher/carr/carr/quiz/tests/test_scores.py", line 106, in test_question_and_quiz_keys
    self.assertEqual(r['answer_key'], {})
AssertionError: {1: 1} != {}
- {1: 1}
+ {}

----------------------------------------------------------------------
Ran 82 tests in 1.567s

FAILED (failures=1)
Destroying test database for alias 'default'...
```

I tracked it down to the cache in
`carr.quiz.scores.question_and_quiz_keys` not being cleared between
tests. So, depending on the order that the tests run, which Django
doesn't really guarantee, it can return cached data.

We could rewrite the tests to all carefully clear the cache between
runs, but it seemed easier to just use the dummy cache for tests.