### PR TITLE
Replace 'onbeforeunload' handlers

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -11,6 +11,7 @@
 				"$$",
 				"ActiveXObject",
 				"addElementClass",
+				"removeElementClass",
 				"alert",
         "confirm",
 				"DIV",

--- a/carr/templates/quiz/quizblock.html
+++ b/carr/templates/quiz/quizblock.html
@@ -61,5 +61,5 @@
 {% endfor %}
 
 <div id ="show_score" class="text-center">
-    <a onMouseUp="saveState()" id="show_score_link" class="btn btn-primary">Submit Your Responses</a>
+    <a onMouseUp="saveState(true)" id="show_score_link" class="btn btn-primary">Submit Your Responses</a>
 </div>

--- a/carr/templates/quiz/quizblock.html
+++ b/carr/templates/quiz/quizblock.html
@@ -61,5 +61,5 @@
 {% endfor %}
 
 <div id ="show_score" class="text-center">
-    <a onMouseUp="showScore()" id="show_score_link" class="btn btn-primary">Submit Your Responses</a>
+    <a onMouseUp="saveState()" id="show_score_link" class="btn btn-primary">Submit Your Responses</a>
 </div>

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -8,6 +8,10 @@ body {
     color: #000;
 }
 
+.busy, .busy * {
+  cursor: wait;
+}
+
 /* ########## Standard elements ########## */
 
 input[type=checkbox], input[type=radio] {

--- a/media/tests/cdm_student_facing.html
+++ b/media/tests/cdm_student_facing.html
@@ -213,7 +213,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>assertVisible</td>
+    <td>waitForVisible</td>
     <td>next</td>
     <td></td>
 </tr>
@@ -305,12 +305,12 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Your answers are incorrect</td>
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>exact:Abuse or Accident?</td>
     <td></td>
 </tr>
@@ -360,17 +360,17 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 3 of 3</td>
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Activity: Abuse or Accident? | Page 3 of 3</td>
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>hot stove</td>
     <td></td>
 </tr>
@@ -425,7 +425,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Your answers are incorrect</td>
     <td></td>
 </tr>
@@ -456,12 +456,12 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>fractured lower incisors</td>
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>reported trauma</td>
     <td></td>
 </tr>
@@ -476,7 +476,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 2 of 11</td>
     <td></td>
 </tr>
@@ -496,7 +496,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 3 of 11</td>
     <td></td>
 </tr>
@@ -511,12 +511,12 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>This is the wrong answer</td>
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>This is the right answer</td>
     <td></td>
 </tr>
@@ -526,12 +526,12 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 4 of 11</td>
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Completed Actions</td>
     <td></td>
 </tr>
@@ -542,7 +542,7 @@
 </tr>
 <!--OK now view the blank report-->
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 5 of 11</td>
     <td></td>
 </tr>
@@ -664,7 +664,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 11 of 11</td>
     <td></td>
 </tr>
@@ -719,7 +719,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 1 of 11</td>
     <td></td>
 </tr>
@@ -729,7 +729,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 2 of 11</td>
     <td></td>
 </tr>
@@ -739,7 +739,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 3 of 11</td>
     <td></td>
 </tr>
@@ -749,7 +749,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 4 of 11</td>
     <td></td>
 </tr>
@@ -779,13 +779,13 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 9 of 11</td>
     <td></td>
 </tr>
 <!--Assert that the text is still there.-->
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td></td>
     <td>(212) 123-4567</td>
 </tr>
@@ -806,7 +806,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Please answer the following questions</td>
     <td></td>
 </tr>
@@ -1084,7 +1084,7 @@
 </tr>
 <!--Final quiz with perfect score is now submitted.-->
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>10 / 10.</td>
     <td></td>
 </tr>
@@ -1095,19 +1095,19 @@
 </tr>
 <!--Pre-test score-->
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>2 / 10</td>
     <td></td>
 </tr>
 <!--Taking action-->
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>The post-test is complete</td>
     <td></td>
 </tr>
 <!--First try-->
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>First try</td>
     <td></td>
 </tr>
@@ -1123,7 +1123,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Your initial score</td>
     <td></td>
 </tr>

--- a/media/tests/student_facing.html
+++ b/media/tests/student_facing.html
@@ -108,7 +108,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>assertVisible</td>
+    <td>waitForVisible</td>
     <td>next</td>
     <td></td>
 </tr>
@@ -169,7 +169,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>assertVisible</td>
+    <td>waitForVisible</td>
     <td>next</td>
     <td></td>
 </tr>
@@ -204,7 +204,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>assertVisible</td>
+    <td>waitForVisible</td>
     <td>next</td>
     <td></td>
 </tr>
@@ -300,17 +300,17 @@
     <td></td>
 </tr>
 <tr>
-    <td>assertVisible</td>
+    <td>waitForVisible</td>
     <td>next</td>
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Your answers are incorrect</td>
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>exact:Abuse or Accident?</td>
     <td></td>
 </tr>
@@ -381,17 +381,17 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 3 of 3</td>
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Activity: Abuse or Accident? | Page 3 of 3</td>
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>blisters</td>
     <td></td>
 </tr>
@@ -446,7 +446,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Your answers are correct</td>
     <td></td>
 </tr>
@@ -477,17 +477,17 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 1 of 11</td>
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>You are working with a father</td>
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>The girl is caught in a bitter</td>
     <td></td>
 </tr>
@@ -502,7 +502,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 2 of 11</td>
     <td></td>
 </tr>
@@ -522,7 +522,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 3 of 11</td>
     <td></td>
 </tr>
@@ -537,12 +537,12 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>This is the wrong answer</td>
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>This is the right answer</td>
     <td></td>
 </tr>
@@ -552,12 +552,12 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 4 of 11</td>
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Completed Actions</td>
     <td></td>
 </tr>
@@ -568,7 +568,7 @@
 </tr>
 <!--OK now view the blank report-->
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 5 of 11</td>
     <td></td>
 </tr>
@@ -679,7 +679,7 @@
 </tr>
 <!-- fill out form -->
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>next time you inquire</td>
     <td></td>
 </tr>
@@ -695,7 +695,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 11 of 11</td>
     <td></td>
 </tr>
@@ -750,7 +750,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 1 of 11</td>
     <td></td>
 </tr>
@@ -760,7 +760,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 2 of 11</td>
     <td></td>
 </tr>
@@ -770,7 +770,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 3 of 11</td>
     <td></td>
 </tr>
@@ -780,7 +780,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 4 of 11</td>
     <td></td>
 </tr>
@@ -810,13 +810,13 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Page 9 of 11</td>
     <td></td>
 </tr>
 <!--Assert that the text is still there.-->
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td></td>
     <td>(212) 123-4567</td>
 </tr>
@@ -842,7 +842,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Please answer the following questions</td>
     <td></td>
 </tr>
@@ -1291,19 +1291,19 @@
 </tr>
 <!--Post-test score-->
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>2 / 10</td>
     <td></td>
 </tr>
 <!--Taking action-->
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>The post-test is complete</td>
     <td></td>
 </tr>
 <!--First try-->
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>First try</td>
     <td></td>
 </tr>
@@ -1319,7 +1319,7 @@
     <td></td>
 </tr>
 <tr>
-    <td>verifyTextPresent</td>
+    <td>waitForTextPresent</td>
     <td>Your initial score</td>
     <td></td>
 </tr>


### PR DESCRIPTION
In quizzes, the bruise recon activity and the taking action activity, the beforeunload event was used to save state synchronously. This event is not supported in iOS. A user yesterday reported issues saving state using an iPad. The bug was easily reproduced.

This PR reworks how state is saved for each of the three activities. In all cases, the operation is now async and handles error messaging appropriately.