### PR TITLE
Refactor: centralize site.domain selection

### DIFF
--- a/carr/middleware.py
+++ b/carr/middleware.py
@@ -5,6 +5,8 @@ from django.contrib.sites.requests import RequestSite
 class SiteIdMiddleware(object):
     def process_request(self, request):
         if 'ssw' in RequestSite(request).domain:
-            settings.SITE_ID = 2
-        else:
-            settings.SITE_ID = 1
+            settings.SITE_ID = settings.SITE_SOCIAL_WORK  # 2
+        elif 'cdm' in RequestSite(request).domain:
+            settings.SITE_ID = settings.SITE_DENTAL  # 1
+
+        # otherwise default to whatever is already set

--- a/carr/quiz/scores.py
+++ b/carr/quiz/scores.py
@@ -57,11 +57,9 @@ def access_list(request):
 
 @user_passes_test(can_see_scores)
 def scores_index(request):
-    current_site = get_current_site(request)
     return render(request, 'quiz/scores/scores_index.html', {
         'full_page_results_block': True,
         'hide_scores_help_text': True,
-        'site_domain': current_site.domain
     })
 
 

--- a/carr/settings_shared.py
+++ b/carr/settings_shared.py
@@ -95,6 +95,8 @@ PAGEBLOCKS = ['pageblocks.HTMLBlock',
               ]
 
 SITE_ID = 1
+SITE_DENTAL = 1
+SITE_SOCIAL_WORK = 2
 
 TEMPLATES[0]['OPTIONS']['context_processors'].append(  # noqa
     'carr.carr_main.views.context_processor',

--- a/carr/templates/activity_taking_action/snippets/possible_actions.html
+++ b/carr/templates/activity_taking_action/snippets/possible_actions.html
@@ -1,4 +1,4 @@
-{% if "cdm" in block.site.domain%} 
+{% if not IS_SOCIALWORK %} 
         <div>
 	        <div class="{{the_step_name}} action_button first_round_action first_round_action_1">
 		        Do Nothing 
@@ -23,7 +23,7 @@
 		        This is the wrong answer because the child is not in imminent danger.
 	        </p>
         </div>
-{%endif%}{% if "ssw" in block.site.domain%} 
+{% else %} 
         <div>
 	        <div class="{{the_step_name}} action_button first_round_action first_round_action_1">
 		        Do Nothing 
@@ -48,7 +48,7 @@
 		        This is the wrong answer because the child is not in imminent danger. 
 	        </p>
         </div>
-    {% if "cdm" in block.site.domain%} 
+    {% if not IS_SOCIALWORK %} 
             <div>
 	            <div class="{{the_step_name}} action_button first_round_action first_round_action_4 correct_choice correct_choice">
 		            Perform clinical and radioactive dental examinations to review the extent of the injury. 
@@ -58,4 +58,4 @@
                 </p>
             </div>
     {%endif%}
-{%endif%} 
+{%endif%}

--- a/carr/templates/activity_taking_action/snippets/your_observations.html
+++ b/carr/templates/activity_taking_action/snippets/your_observations.html
@@ -1,7 +1,7 @@
 <p class="half-page_heading">
 	Your Observations 
 </p>
-{% if "cdm" in block.site.domain%} 
+{% if not IS_SOCIALWORK %} 
     <p>
 	    <input type="checkbox" class="{{the_step_name}} checkbox observation observation_1" />
 	    The child's injuries are consistent with the history of reported trauma. 
@@ -18,7 +18,7 @@
 	    <input type="checkbox" class="{{the_step_name}} checkbox observation observation_4" />
 	    The lower teeth are injured. 
     </p>
-{%endif%} {% if "ssw" in block.site.domain%} 
+{% else %}
     <p>
 	    <input type="checkbox" class="{{the_step_name}} checkbox observation observation_1" />
 	    The girl is caught in a bitter divorce and custody battle. 

--- a/carr/templates/activity_taking_action/step_case_summary.html
+++ b/carr/templates/activity_taking_action/step_case_summary.html
@@ -1,17 +1,43 @@
 <div class="activity_step" id="{{the_step_name}}">
-	<h5>
-		Case Summary 
-	</h5>
-	<p>
-		{% if "cdm" in block.site.domain%} A mother brings her 3 year old son to your clinic for a check-up. During the exam, you notice a laceration on the child's lip, and fractured lower incisors. Upon questioning the mother, she tells you that the child hurt himself accidentally when he ran into a doorknob four days ago. You notice that the child is too short to have sustained the injury on a doorknob. Furthermore, running into a doorknob is not likely to cause a lip laceration, and most mouth injuries impact the upper, not the lower teeth. The child is too young to tell you what happened, and the mother's story is not reasonable. Although the child does not appear to be in imminent danger, you cannot rule out that he has not been abused. You call the SCR to file a report and within the next 2 days, you complete and submit the LDSS-2221A. If the SCR determines that the child may be in an abusive home, the local authorities will be contacted. Your job as a mandated reporter is complete. {%endif%}
-{% if "ssw" in block.site.domain%}
-    {% include "activity_taking_action/snippets/case_history_text.html" %}
-    <br/><br/>
-    You notice that the child is caught in a bitter divorce, and her father may be resorting to dishonest and manipulative tactics in order to win custody of his daughter. The girl doesn't say much, but she doesn't disagree with what her father is alleging.<br/><br/>
-    Although the child does not appear to be in imminent danger, you cannot rule out that the mother's boyfriend is a danger to the child. You call the State Central Register (SCR) to file a report and within the next 2 days (48 hours), you must complete and submit the LDSS-2221A. If the SCR determines that the child may be in an abusive home, the local authorities will be contacted. Your job as a mandated reporter is complete.<br/><br/>
-    You are interested in the case and would like to follow-up. A week after calling CPS and submitting the LDSS-2221A, you request the findings of this investigation. Once SCR confirms your identity, you learn that investigation has not been completed, you are informed that the report is "under investigation." The next time you inquire about the report, you learn that it is "unfounded."
-{%endif%} 
-	</p>
+    <h5>Case Summary</h5>
+    <p>
+        {% if not IS_SOCIALWORK %}
+        A mother brings her 3 year old son to your
+        clinic for a check-up. During the exam, you notice a laceration on the
+        child's lip, and fractured lower incisors. Upon questioning the mother,
+        she tells you that the chil hurt himself accidentally when he ran into a
+        doorknob four days ago. You notice that the child is too short to have
+        sustained the injury on a doorknob. Furthermore, running into a doorknob
+        is not likely to cause a lip laceration, and most mouth injuries impact
+        the upper, not the lower teeth. The child is too young to tell you what
+        happened, and the mother's story is not reasonable. Although the child
+        does not appear to be in imminent danger, you cannot rule out that he
+        has not been abused. You call the SCR to file a report and within the
+        next 2 days, you complete and submit the LDSS-2221A. If the SCR
+        determines that the child may be in an abusive home, the local
+        authorities will be contacted. Your job as a mandated reporter is
+        complete.
+        {% else %}
+        {% include "activity_taking_action/snippets/case_history_text.html" %} <br />
+        <br /> You notice that the child is caught in a bitter divorce, and her
+        father may be resorting to dishonest and manipulative tactics in order
+        to win custody of his daughter. The girl doesn't say much, but she
+        doesn't disagree with what her father is alleging.<br />
+        <br /> Although the child does not appear to be in imminent danger, you
+        cannot rule out that the mother's boyfriend is a danger to the child.
+        You call the State Central Register (SCR) to file a report and within
+        the next 2 days (48 hours), you must complete and submit the LDSS-2221A.
+        If the SCR determines that the child may be in an abusive home, the
+        local authorities will be contacted. Your job as a mandated reporter is
+        complete.<br />
+        <br /> You are interested in the case and would like to follow-up. A
+        week after calling CPS and submitting the LDSS-2221A, you request the
+        findings of this investigation. Once SCR confirms your identity, you
+        learn that investigation has not been completed, you are informed that
+        the report is "under investigation." The next time you inquire about the
+        report, you learn that it is "unfounded."
+        {%endif%}
+    </p>
     <div class="purple_button taking_action_prev_button">Back</div>
-	<div class ="taking_action_pagenumber">Page 11 of 11</div>
+    <div class="taking_action_pagenumber">Page 11 of 11</div>
 </div>

--- a/carr/templates/activity_taking_action/step_review_case_history.html
+++ b/carr/templates/activity_taking_action/step_review_case_history.html
@@ -1,14 +1,18 @@
 <div class="activity_step" id="{{the_step_name}}">
 		<p>
-		Read the case study below, then check the boxes that correspond to your observations about the case. Enter any additional information in the text box. Then click the "Next" button.
+		Read the case study below, then check the boxes that correspond to your observations about the case.
+        Enter any additional information in the text box. Then click the "Next" button.
 		</p>
 	<div class="half-page">
 		<p class="half-page_heading">
 			Case History
 		</p>
 		<div id="review_case_history_copy">
-			{% if "cdm" in block.site.domain%} A mother brings her 3 year old son to your clinic for a check-up. During the exam, you notice a laceration on the child's lip, and fractured lower incisors. Upon questioning the mother, she tells you that the child hurt himself accidentally when he ran into a doorknob four days ago. {%endif%}
-			{% if "ssw" in block.site.domain%} 
+			{% if not IS_SOCIALWORK %}
+                A mother brings her 3 year old son to your clinic for a check-up. During the exam, you notice
+                a laceration on the child's lip, and fractured lower incisors. Upon questioning the mother,
+                she tells you that the child hurt himself accidentally when he ran into a doorknob four days ago.
+            {% else %}
                 {% include "activity_taking_action/snippets/case_history_text.html" %}
 			{%endif%}
 		</div>

--- a/carr/templates/admin/carr_main/sitesection/change_list.html
+++ b/carr/templates/admin/carr_main/sitesection/change_list.html
@@ -32,19 +32,9 @@
 					      <b>{{s.label}}</b>
 					   {% endifnotequal %}
                             {%for site in s.sites%}
-                                      {%if "cdm" in site.domain %}<span style="color:purple">cdm</span>{% endif%}		
-                                      {%if "ssw" in site.domain %}<span style="color:red">ssw</span>{% endif%}			   
+                                      {%if not IS_SOCIALWORK %}<span style="color:purple">cdm</span>{% endif%}		
+                                      {%if IS_SOCIALWORK %}<span style="color:red">ssw</span>{% endif%}			   
                             {%endfor %}
-                            <!--
-                                {%if "cdm" in sssss.domain %}dental
-                                {%else%}
-                                {%endif%}
-                                
-                                {%if "ssw" in sssss.domain %}social work
-                                {%else%}
-                                {%endif%}
-
-					-->
 						{% with s.get_children as has_children %}
 							{% if has_children %}<ul>{% endif %}
 							{% if not has_children and s.is_last_child %}</ul>{% endif %}

--- a/carr/templates/base.html
+++ b/carr/templates/base.html
@@ -10,12 +10,12 @@
     {% compress css %}
     <link rel="stylesheet" href="{{ STATIC_URL }}css/main.css" media="screen" />
     {% endcompress %}
-    {% if "cdm" in site_domain %}
+    {% if IS_SOCIALWORK %}
+        <link rel="stylesheet" href="{{STATIC_URL}}css/ssw.css" media="screen" />
+    {% else %}
         <link rel="stylesheet" href="{{STATIC_URL}}css/cdm.css" media="screen" />
     {% endif %}
-    {% if "ssw" in site_domain %}
-        <link rel="stylesheet" href="{{STATIC_URL}}css/ssw.css" media="screen" />
-    {% endif %}
+
     <!--[if IE 6]>
     <link rel="stylesheet" href="{{STATIC_URL}}css/main_ie6_2coll.css" media="screen" />
     <![endif]-->
@@ -89,17 +89,17 @@ gtag('config', '{{GA_TAG}}', { 'anonymize_ip': true });
         <!-- CCNMTL title/logo -->
         <a id="logo_ccnmtl" href="http://ccnmtl.columbia.edu" target="_blank" title="Columbia Center for New Media Teaching and Learning">
             <img src="{{STATIC_URL}}img/logo_ccnmtl.png" alt="CCNMTL Logo" />
-        </a>        
-        {% if "cdm" in site_domain %}
+        </a>
+        {% if IS_SOCIALWORK %}
+        <a id="logo_school" href="http://socialwork.columbia.edu" target="_blank" title="Columbia University School of Social Work">
+            <img src="{{STATIC_URL}}img/logo_cussw.gif" alt="CUSSW Logo" />
+        </a>
+        {% else %}
             <a id="logo_school" href="http://dental.columbia.edu" target="_blank" title="Columbia University College of Dental Medicine">
                 <img src="{{STATIC_URL}}img/logo_dental.png"  alt="CDM Logo" />
             </a>
-        {% else %}{% if "ssw" in site_domain %}
-            <a id="logo_school" href="http://socialwork.columbia.edu" target="_blank" title="Columbia University School of Social Work">
-                <img src="{{STATIC_URL}}img/logo_cussw.gif" alt="CUSSW Logo" />
-            </a>        
-        {% endif %}{% endif %}
-    </div>    
+        {% endif %}
+    </div>
 {% endblock %}
 
 <!-- ###### Don't touch this ###### -->
@@ -144,6 +144,11 @@ gtag('config', '{{GA_TAG}}', { 'anonymize_ip': true });
     </div><!-- id="footer" -->
 {% endblock %}
 
+<script>
+    const CARE = {
+        isSocialWork: {% if IS_SOCIALWORK %}true{% else %}false{% endif %}
+    }
+</script>
 
 </div><!-- id="container" -->
 </body>

--- a/carr/templates/carr_main/page.html
+++ b/carr/templates/carr_main/page.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load lti_utils %}
+{% load render %}
 
 {% block title %}{{section.label}}{% endblock %}
 
@@ -37,7 +38,7 @@
    {% else %}
         <h2>{{ section.label }}</h2>
         {% for block in section.pageblock_set.all %}
-            {{ block.render }}
+            {% render block %}
         {% endfor %}
 
         {% if not next %}

--- a/carr/templates/carr_main/selenium.html
+++ b/carr/templates/carr_main/selenium.html
@@ -1,5 +1,3 @@
-
-
 <div>
   Welcome to the selenium setup/teardown page.
 </div>

--- a/carr/templates/quiz/scores/scores_index.html
+++ b/carr/templates/quiz/scores/scores_index.html
@@ -14,7 +14,7 @@
     <div>
         <h1>Student Scores</h1>
         <br />
-        {% if "ssw" in site_domain %}
+        {% if IS_SOCIALWORK %}
             <p>To find a student's scores, click one of the buttons below.</p>
             <p><a class="btn btn-primary btn-large" color="white"  href = "/scores/socialwork/uni/">Search by UNI</a>
 
@@ -24,14 +24,14 @@
 
         <p>Click the button below to download a table of all students' scores. This operation may take a few minutes.</p>
         <p>
-        {% if "ssw" in site_domain %}
+        {% if IS_SOCIAL_WORK %}
             <a class="btn btn-primary btn-large" color="white" href = "/stats/ssw/" target="_blank">All SSW Scores <i class="icon-download-alt icon-white"></i></a>
-        {% else %}{% if "cdm" in site_domain %}
+        {% else %}
             <a class="btn btn-primary btn-large" color="white" href = "/stats/dental/" target="_blank">All Dental Scores <i class="icon-download-alt icon-white"></i></a>
-        {% endif %}{% endif %}
+        {% endif %}
         </p>
 
-        {% if "ssw" in site_domain %}
+        {% if IS_SOCIALWORK %}
             <br />
             <p>Download a question by question analysis of the post-test.</p>
             <form method="post" action="/scores/socialwork/analysis/">

--- a/carr/templates/quiz/scores_faculty_course.html
+++ b/carr/templates/quiz/scores_faculty_course.html
@@ -51,28 +51,30 @@
                 {%with st.score_on_bruise_recon as a%} 
                    {%if a %}
                         {{a}} / 3
-	                    {% if "cdm" in site_domain%}
-		                      ( <a href="/activity/bruise_recon/studentcase/1/user/{{st.student.id}}/">1</a>
-		                        <a href="/activity/bruise_recon/studentcase/2/user/{{st.student.id}}/">2</a>
-		                        <a href="/activity/bruise_recon/studentcase/3/user/{{st.student.id}}/">3</a>)
-		                {%else %}
-		                      ( <a href="/activity/bruise_recon/studentcase/4/user/{{st.student.id}}/">1</a>
-		                        <a href="/activity/bruise_recon/studentcase/5/user/{{st.student.id}}/">2</a>
-		                        <a href="/activity/bruise_recon/studentcase/6/user/{{st.student.id}}/">3</a>) 
-		                {%endif%}
+                        {% if IS_SOCIALWORK %}
+                            ( <a href="/activity/bruise_recon/studentcase/4/user/{{st.student.id}}/">1</a>
+                                <a href="/activity/bruise_recon/studentcase/5/user/{{st.student.id}}/">2</a>
+                                <a href="/activity/bruise_recon/studentcase/6/user/{{st.student.id}}/">3</a>) 
+                        {% else %}
+                              ( <a href="/activity/bruise_recon/studentcase/1/user/{{st.student.id}}/">1</a>
+                                <a href="/activity/bruise_recon/studentcase/2/user/{{st.student.id}}/">2</a>
+                                <a href="/activity/bruise_recon/studentcase/3/user/{{st.student.id}}/">3</a>)
+                        {%endif%}
                   {%else%}
                             {%if a == 0 %}
                                 {{a}} / 3
-                                {% if "cdm" in site_domain%}
-	                                  ( <a href="/activity/bruise_recon/studentcase/1/user/{{st.student.id}}/">1</a>
-	                                    <a href="/activity/bruise_recon/studentcase/2/user/{{st.student.id}}/">2</a>
-	                                    <a href="/activity/bruise_recon/studentcase/3/user/{{st.student.id}}/">3</a>)
-	                            {%else %}
-	                                  ( <a href="/activity/bruise_recon/studentcase/4/user/{{st.student.id}}/">1</a>
-	                                    <a href="/activity/bruise_recon/studentcase/5/user/{{st.student.id}}/">2</a>
-	                                    <a href="/activity/bruise_recon/studentcase/6/user/{{st.student.id}}/">3</a>) 
-	                            {%endif%}
-                            {%else %}Incomplete{%endif%}
+                                {% if IS_SOCIALWORK %}
+                                      ( <a href="/activity/bruise_recon/studentcase/4/user/{{st.student.id}}/">1</a>
+                                        <a href="/activity/bruise_recon/studentcase/5/user/{{st.student.id}}/">2</a>
+                                        <a href="/activity/bruise_recon/studentcase/6/user/{{st.student.id}}/">3</a>) 
+                                {% else %}
+                                      ( <a href="/activity/bruise_recon/studentcase/1/user/{{st.student.id}}/">1</a>
+                                        <a href="/activity/bruise_recon/studentcase/2/user/{{st.student.id}}/">2</a>
+                                        <a href="/activity/bruise_recon/studentcase/3/user/{{st.student.id}}/">3</a>)
+                                {% endif%}
+                            {% else %}
+                                Incomplete
+                            {% endif %}
                     {%endif%}
                 {%endwith%}
             </td>
@@ -101,16 +103,15 @@
                 {%endif %}
             </td>
             <td>
-            
-	            {%ifequal st.score_on_taking_action 'completed_form' %}
-	              <a href ="/activity/taking_action/student/{{st.student.id}}/">Completed activity and filled out form</a>
-		          {%endifequal%}
+                {%ifequal st.score_on_taking_action 'completed_form' %}
+                  <a href ="/activity/taking_action/student/{{st.student.id}}/">Completed activity and filled out form</a>
+                  {%endifequal%}
               {%ifequal st.score_on_taking_action 'clicked_through' %}
-	              Complete
-		          {%endifequal%}
+                  Complete
+                  {%endifequal%}
               {%ifequal st.score_on_taking_action 'no_data' %}
-	              Incomplete
-		          {%endifequal%}
+                  Incomplete
+                  {%endifequal%}
             </td>
             <td>
                 {% get_scores for 'post-test' in st.scores as score %}
@@ -141,31 +142,31 @@
                     Incomplete
                 {%endif %}
             </td>
-            
+
         </tr>
         {%endfor %}
         <tr>
           <td colspan = "12">
-          
-			<p>
-			Students in courses: 
-			</p>
-			
-			<ul>
-			
-			<li>
-			<b>prior to 2011</b> may have "n/a" appear on their scores. 
-			</li>
-			
-			<li>
-			<b>from 2011 onward</b> should not have "n/a" appear on their scores.    
-			</li>
-			
-			</ul>
-			
-			<p>
-			If you have a student with "n/a" as a score somewhere, please contact <a href="mailto:ccnmtl-care@columbia.edu">ccnmtl-care@columbia.edu</a> for more information about what that means.
-			</p>
+
+            <p>
+            Students in courses: 
+            </p>
+
+            <ul>
+
+            <li>
+            <b>prior to 2011</b> may have "n/a" appear on their scores. 
+            </li>
+
+            <li>
+            <b>from 2011 onward</b> should not have "n/a" appear on their scores.    
+            </li>
+
+            </ul>
+
+            <p>
+            If you have a student with "n/a" as a score somewhere, please contact <a href="mailto:ccnmtl-care@columbia.edu">ccnmtl-care@columbia.edu</a> for more information about what that means.
+            </p>
 
           </td>
         </td>

--- a/carr/templates/quiz/scores_student.html
+++ b/carr/templates/quiz/scores_student.html
@@ -56,7 +56,7 @@
     </tr>
     
     
-    {% if "ssw" in site.domain%}
+    {% if IS_SOCIALWORK %}
                 <tr>
                     <td>
                         Case 1

--- a/carr/utils.py
+++ b/carr/utils.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.contrib.sites.shortcuts import get_current_site
 
 
 def state_json(state_class, user):
@@ -30,3 +31,7 @@ def filter_users_by_affiliation(affiliation, the_users):
         return the_users.filter(groups__name__regex=regex)
     else:
         return the_users.exclude(groups__name__regex=regex)
+
+
+def is_socialwork(request):
+    return get_current_site(request).id == settings.SITE_SOCIAL_WORK

--- a/media/js/quiz/quiz.js
+++ b/media/js/quiz/quiz.js
@@ -1,7 +1,7 @@
 /*eslint no-unused-vars: ["error", {
   "varsIgnorePattern":
-  "is_cdm|cheat|number_of_questions_to_answer|retakeQuiz" }]*/
-/* global student_quiz: true */
+  "cheat|number_of_questions_to_answer|retakeQuiz" }]*/
+/* global student_quiz: true, CARE: true */
 
 function randomly() {
     return 0.5 - Math.random();
@@ -154,11 +154,6 @@ function thaw_buttons() {
 function calculate_order() {
     // Returns a list of database ID's of questions
     // in the order this quiz should display them.
-    var my_url = location.href;
-    var is_ssw = (my_url.match(/ssw/) !== null) ||
-        (my_url.match(/64757/) !== null);
-    var is_cdm = (my_url.match(/cdm/) !== null) ||
-        (my_url.match(/64756/) !== null);
 
     if (post_test) {
         // Show some required questions, and some questions
@@ -175,7 +170,7 @@ function calculate_order() {
         var how_many_randomly_picked_questions;
         // How many of the questions that *might* be on the quiz
         // should we add to the ones that *will* be?
-        if (is_ssw) {
+        if (CARE.isSocialWork) {
             // last-minute change: the dental school professor wants
             // to remove the randomly-picked questions:
             how_many_randomly_picked_questions = 10;


### PR DESCRIPTION
This PR consolidates the `site.domain` selection to the `middleware.py`, and the template and application site tests (is dental? is ssw?) to a utility function and context processor.

Previously, the code was testing the url and the `site.id` in many different locations, making it difficult to easily test the dental flow vs. the ssw flow.