### PR TITLE
quizzes: remove hard-coded database ids

### DIFF
--- a/carr/carr_main/templatetags/carr_main_template_tags.py
+++ b/carr/carr_main/templatetags/carr_main_template_tags.py
@@ -1,8 +1,12 @@
 from django import template
 from django.conf import settings
-from carr.carr_main.models import user_type as user_type_f
-from carr.carr_main.models import classes_i_teach as classes_i_teach_f
+from django.template.loader import get_template
+from pagetree.templatetags.render import RenderNode
+
 from carr.carr_main.models import classes_i_take as classes_i_take_f
+from carr.carr_main.models import classes_i_teach as classes_i_teach_f
+from carr.carr_main.models import user_type as user_type_f
+
 
 register = template.Library()
 
@@ -25,3 +29,22 @@ def classes_i_teach(user, *args):
 @register.assignment_tag
 def classes_i_take(user, *args):
     return classes_i_take_f(user)
+
+
+class RenderJSNode(RenderNode):
+
+    def render(self, context):
+        content_object = context[self.block].content_object
+        if hasattr(content_object, 'js_template_file'):
+            t = get_template(getattr(content_object, 'js_template_file'))
+            d = {}
+            d['block'] = content_object
+            return t.render(d)
+        else:
+            return ""
+
+
+@register.tag('renderjs')
+def renderjs(parser, token):
+    block = token.split_contents()[1:][0]
+    return RenderJSNode(block)

--- a/carr/quiz/admin.py
+++ b/carr/quiz/admin.py
@@ -15,7 +15,8 @@ class AnswerInline (admin.TabularInline):
 
 class QuestionAdmin(admin.ModelAdmin):
     search_fields = ['value']
-    list_display = ['text', 'quiz', 'ordinality']
+    list_display = ['id', 'quiz', 'ordinality',
+                    'optional', 'required', 'text']
     inlines = [AnswerInline]
 
 

--- a/carr/quiz/models.py
+++ b/carr/quiz/models.py
@@ -12,6 +12,7 @@ class Quiz(models.Model):
     description = models.TextField(blank=True)
     rhetorical = models.BooleanField(default=False)
     template_file = "quiz/quizblock.html"
+    js_template_file = "quiz/quizblock_js.html"
 
     display_name = "Quiz"
 
@@ -98,6 +99,14 @@ class Quiz(models.Model):
 
     def questions(self):
         return self.question_set.all().prefetch_related('answer_set')
+
+    def required_questions(self):
+        return self.question_set.filter(
+            required=True).order_by('id').prefetch_related('answer_set')
+
+    def optional_questions(self):
+        return self.question_set.filter(
+            optional=True).order_by('id').prefetch_related('answer_set')
 
 
 class Question(models.Model):

--- a/carr/templates/carr_main/page.html
+++ b/carr/templates/carr_main/page.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load lti_utils %}
 {% load render %}
+{% load carr_main_template_tags %}
 
 {% block title %}{{section.label}}{% endblock %}
 
@@ -90,4 +91,10 @@
       </ul>
     </nav>
     </div>
+{% endblock %}
+
+{% block js %}
+    {% for block in section.pageblock_set.all %}
+        {% renderjs block %}
+    {% endfor %}
 {% endblock %}

--- a/carr/templates/quiz/quizblock_js.html
+++ b/carr/templates/quiz/quizblock_js.html
@@ -1,0 +1,15 @@
+
+<script type="text/javascript">
+
+// Show some required questions, and some questions
+// picked at random out of a hat, in a random order.
+// These questions *will* be on the quiz regardless of
+// the order the questions are presented in:
+var required_questions = [
+{% for question in block.required_questions %}{{question.id}}{% if not forloop.last %}, {% endif %}{% endfor %}
+];
+
+var optional_questions = [
+{% for question in block.optional_questions %}{{question.id}}{% if not forloop.last %}, {% endif %}{% endfor %}
+];
+</script>

--- a/media/js/quiz/quiz.js
+++ b/media/js/quiz/quiz.js
@@ -1,7 +1,8 @@
 /*eslint no-unused-vars: ["error", {
   "varsIgnorePattern":
   "cheat|number_of_questions_to_answer|retakeQuiz" }]*/
-/* global student_quiz: true, CARE: true */
+/* global student_quiz: true, CARE: true, required_questions: true */
+/* global optional_questions: true */
 
 function randomly() {
     return 0.5 - Math.random();
@@ -154,52 +155,34 @@ function thaw_buttons() {
 function calculate_order() {
     // Returns a list of database ID's of questions
     // in the order this quiz should display them.
+    // required_questions & optional_questions are rendered
+    // via the quiz block
 
     if (post_test) {
-        // Show some required questions, and some questions
-        // picked at random out of a hat, in a random order.
-        // These questions *will* be on the quiz regardless of
-        // the order the questions are presented in:
-        var required_questions = [13, 14, 15, 16, 17, 18, 19, 20, 21, 22];
-
-        // Questions that *might* be on the quiz:
-        var randomly_picked_questions = [
-            23, 24, 25, 26, 27, 28, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
-            40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 51, 52];
-
-        var how_many_randomly_picked_questions;
-        // How many of the questions that *might* be on the quiz
-        // should we add to the ones that *will* be?
         if (CARE.isSocialWork) {
-            // last-minute change: the dental school professor wants
-            // to remove the randomly-picked questions:
-            how_many_randomly_picked_questions = 10;
-        } else {
-            how_many_randomly_picked_questions = 0;
+            // SSW adds 10 random questions to the required questions
+
+            // shuffle the randomly picked questions:
+            optional_questions.sort(randomly);
+
+            // ok, pick a certain number out of the urn --
+            // assign length in order to pick.
+            optional_questions.length = 10;
+
+            required_questions = required_questions.concat(
+                optional_questions);
         }
-        // shuffle the randomly picked questions:
-        randomly_picked_questions.sort(randomly);
-
-        // ok, pick a certain number out of the urn --
-        // assign length in order to pick.
-        randomly_picked_questions.length =
-            how_many_randomly_picked_questions;
-
-        var final_list_of_questions = required_questions.concat(
-            randomly_picked_questions);
 
         // reshuffle all questions together:
-        final_list_of_questions.sort(randomly);
+        required_questions.sort(randomly);
 
         var question_ids_as_loaded = map(function(a) {
             return parseInt(a.id.split('_')[1]);
         },  $$('.cases.really'));
 
-        var question_ids_as_needed = final_list_of_questions;
-
         var order = map(function(a) {
             return findValue(question_ids_as_loaded, a);
-        }, question_ids_as_needed);
+        }, required_questions);
         return order;
     } else {
         return list(range($$('.cases.really').length)).sort(randomly);


### PR DESCRIPTION
The Post Test quiz handles question selection, randomization and display on the client side. This PR removes two arrays of hard-coded database ids from clientside javascript. These arrays are now dynamically rendered based on the list of question objects.

* Added functionality to allow custom blocks to render javascript. This functionality is in later versions of `django-pagetree`. Unfortunately, CARR is stuck on an earlier version due to some unfortunate monkey patches on the `Section` object.

* Required & optional questions are retrieved from the Quiz model and rendered out in the `quizblock.html` template.

* A little refactoring completed in `quiz.js` to remove extraneous variables and simplify the code.