### PR TITLE
Use pylibmc for memcached bindings

### DIFF
--- a/carr/settings_production.py
+++ b/carr/settings_production.py
@@ -14,7 +14,7 @@ locals().update(
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
         'LOCATION': '127.0.0.1:11211',
     }
 }

--- a/carr/settings_staging.py
+++ b/carr/settings_staging.py
@@ -14,7 +14,7 @@ locals().update(
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.PyLibMCCache',
         'LOCATION': '127.0.0.1:11211',
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,8 @@ python-dateutil==2.8.1
 django-storages==1.8 # pyup: <1.9
 
 django-cacheds3storage==0.2.1
-python-memcached==1.59
+# memcached
+pylibmc==1.6.1
 django-smtp-ssl==1.0
 
 ccnmtlsettings==1.8.0


### PR DESCRIPTION
This library is better maintained than python-memcached.