### PR TITLE
Only install pylibmc on linux

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ django-storages==1.8 # pyup: <1.9
 
 django-cacheds3storage==0.2.1
 # memcached
-pylibmc==1.6.1
+pylibmc==1.6.1; sys_platform == 'linux'
 django-smtp-ssl==1.0
 
 ccnmtlsettings==1.8.0


### PR DESCRIPTION
This fails on macOS. It's possible to get this package to compile with
something like:

brew install libmemcached
pip install pylibmc --install-option="--with-libmemcached=/usr/local/Cellar/libmemcached/1.0.18_2/"

But, I'm not sure how to hook up those path options to requirements.txt,
and besides, we don't need to test memcached stuff on our dev mac
laptops.