### PR TITLE
Remove libmemcached headers from github actions build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,8 +7,6 @@ jobs:
       matrix:
           python-version: [3.8]
     steps:
-      - uses: actions/checkout@v2
-      - name: install memcached headers
-        run: sudo apt install -y libmemcached-dev
+      - uses: actions/checkout@v3
       - name: Build with Makefile
         run: make


### PR DESCRIPTION
This apt package isn't installing for some reason. I don't think it's required for testing, so we can just remove it from here.

```
The following packages have unmet dependencies:
 libmemcached-dev : Depends: libhashkit-dev (= 1.0.18-4.2ubuntu2) but it
 is not going to be installed
                     Depends: libmemcached11 (= 1.0.18-4.2ubuntu2) but
                     1.1.3-1+ubuntu20.04.1+deb.sury.org+1 is to be
                       installed
                       E: Unable to correct problems, you have held
                       broken packages.
                       Error: Process completed with exit code 100.
```
https://github.com/ccnmtl/carr/actions/runs/5348992945/jobs/9699595779