### PR TITLE
assertEquals() -> assertEqual()

### DIFF
--- a/carr/carr_main/tests/test_utils.py
+++ b/carr/carr_main/tests/test_utils.py
@@ -15,15 +15,15 @@ class TestUtils(TestCase):
         u = UserFactory()
 
         # no state
-        self.assertEquals(state_json(ActivityState, u), '{}')
+        self.assertEqual(state_json(ActivityState, u), '{}')
 
         # empty state
         state = ActivityState.objects.create(user=u, json='')
-        self.assertEquals(state_json(ActivityState, u), '{}')
+        self.assertEqual(state_json(ActivityState, u), '{}')
 
         state.json = dumps(some_state)
         state.save()
-        self.assertEquals(state_json(ActivityState, u), state.json)
+        self.assertEqual(state_json(ActivityState, u), state.json)
 
     def test_get_and_filter_students(self):
         with self.settings(DEFAULT_SOCIALWORK_FACULTY_UNIS=['ssw_faculty']):
@@ -39,14 +39,14 @@ class TestUtils(TestCase):
             UserFactory().groups.add(GroupFactory(name='a.fc.b'))  # faculty
 
             students = get_students()
-            self.assertEquals(students.count(), 2)
-            self.assertEquals(students[0], dental_student)
-            self.assertEquals(students[1], ssw_student)
+            self.assertEqual(students.count(), 2)
+            self.assertEqual(students[0], dental_student)
+            self.assertEqual(students[1], ssw_student)
 
             qs = filter_users_by_affiliation('dental', students)
-            self.assertEquals(qs.count(), 1)
-            self.assertEquals(qs.first(), dental_student)
+            self.assertEqual(qs.count(), 1)
+            self.assertEqual(qs.first(), dental_student)
 
             qs = filter_users_by_affiliation('ssw', students)
-            self.assertEquals(qs.count(), 1)
-            self.assertEquals(qs.first(), ssw_student)
+            self.assertEqual(qs.count(), 1)
+            self.assertEqual(qs.first(), ssw_student)

--- a/carr/carr_main/tests/test_views.py
+++ b/carr/carr_main/tests/test_views.py
@@ -139,36 +139,36 @@ class TestHierarchyNavigation(TestCase):
         with self.settings(SITE_ID=self.site.id):
             menu = _construct_menu(
                 self.ss.user, self.root, self.section3, self.ss)
-            self.assertEquals(len(menu), 3)
+            self.assertEqual(len(menu), 3)
 
-            self.assertEquals(menu[0]['section'].label, self.section1.label)
+            self.assertEqual(menu[0]['section'].label, self.section1.label)
             self.assertTrue(menu[0]['accessible'])
 
-            self.assertEquals(menu[1]['section'].label, self.section2.label)
+            self.assertEqual(menu[1]['section'].label, self.section2.label)
             self.assertFalse(menu[1]['accessible'])
 
-            self.assertEquals(menu[2]['section'].label, self.section3.label)
+            self.assertEqual(menu[2]['section'].label, self.section3.label)
             self.assertFalse(menu[2]['accessible'])
             self.assertTrue(menu[2]['selected'])
 
     def test_hierarchy_navigation(self):
         with self.settings(SITE_ID=self.site.id):
             kids = self.root.get_children()
-            self.assertEquals(len(kids), 3)
-            self.assertEquals(kids[0].sitesection, self.section1)
-            self.assertEquals(kids[1].sitesection, self.section2)
-            self.assertEquals(kids[2].sitesection, self.section3)
+            self.assertEqual(len(kids), 3)
+            self.assertEqual(kids[0].sitesection, self.section1)
+            self.assertEqual(kids[1].sitesection, self.section2)
+            self.assertEqual(kids[2].sitesection, self.section3)
 
             sibs = self.section1.get_siblings()
-            self.assertEquals(len(sibs), 3)
-            self.assertEquals(sibs[0].sitesection, self.section1)
-            self.assertEquals(sibs[1].sitesection, self.section2)
-            self.assertEquals(sibs[2].sitesection, self.section3)
+            self.assertEqual(len(sibs), 3)
+            self.assertEqual(sibs[0].sitesection, self.section1)
+            self.assertEqual(sibs[1].sitesection, self.section2)
+            self.assertEqual(sibs[2].sitesection, self.section3)
 
-            self.assertEquals(
+            self.assertEqual(
                 self.section2.sitesection.get_previous_site_section(),
                 self.section1)
-            self.assertEquals(
+            self.assertEqual(
                 self.section1.sitesection.get_next_site_section(),
                 self.section2)
             self.assertIsNone(self.section3.get_next_site_section())

--- a/carr/quiz/tests/test_scores.py
+++ b/carr/quiz/tests/test_scores.py
@@ -179,27 +179,27 @@ class TestPostTestAnalysisView(TestCase):
         # not logged in
         url = reverse('post-test-analysis')
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
         # accessing as student
         student = UserFactory()
         self.client.login(username=student.username, password='test')
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
         # using get
         faculty = UserFactory(is_staff=True)
         self.client.login(username=faculty.username, password='test')
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 405)
+        self.assertEqual(response.status_code, 405)
 
     def test_get_posttest(self):
-        self.assertEquals(PostTestAnalysisView().get_posttest(), self.quiz)
+        self.assertEqual(PostTestAnalysisView().get_posttest(), self.quiz)
 
     def test_correct_answer(self):
         view = PostTestAnalysisView()
-        self.assertEquals(view.correct_answer_id(self.question1),
-                          str(self.correct.id))
+        self.assertEqual(view.correct_answer_id(self.question1),
+                         str(self.correct.id))
 
     def test_initialize(self):
         view = PostTestAnalysisView()
@@ -207,9 +207,9 @@ class TestPostTestAnalysisView(TestCase):
 
         key = str(self.question1.id)
         self.assertTrue(key in results)
-        self.assertEquals(results[key]['id'], self.question1.id)
-        self.assertEquals(results[key]['text'], 'foo')
-        self.assertEquals(results[key]['answer'], str(self.correct.id))
+        self.assertEqual(results[key]['id'], self.question1.id)
+        self.assertEqual(results[key]['text'], 'foo')
+        self.assertEqual(results[key]['answer'], str(self.correct.id))
 
     def test_analyze(self):
         u = UserFactory()
@@ -223,8 +223,8 @@ class TestPostTestAnalysisView(TestCase):
         results = view.analyze(self.quiz, results)
 
         key = str(self.question1.id)
-        self.assertEquals(results[key]['responses'], 1)
-        self.assertEquals(results[key]['correct'], 0)
+        self.assertEqual(results[key]['responses'], 1)
+        self.assertEqual(results[key]['correct'], 0)
 
     def test_post(self):
         ActivityState.objects.create(user=UserFactory(),

--- a/carr/quiz/tests/test_views.py
+++ b/carr/quiz/tests/test_views.py
@@ -64,7 +64,7 @@ class TestQuizViews(TestCase):
         request.user = UserFactory(is_staff=True)
 
         response = edit_quiz(request, self.quiz.id)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     def test_delete_question(self):
         staff = UserFactory(is_staff=True)
@@ -73,15 +73,15 @@ class TestQuizViews(TestCase):
 
         # are you sure view
         response = delete_question(request, self.question1.id)
-        self.assertEquals(self.quiz.question_set.count(), 2)
+        self.assertEqual(self.quiz.question_set.count(), 2)
         self.assertContains(response, 'Are you sure')
 
         # delete
         request = RequestFactory().post('/')
         request.user = staff
         response = delete_question(request, self.question1.id)
-        self.assertEquals(response.status_code, 302)
-        self.assertEquals(self.quiz.question_set.count(), 1)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(self.quiz.question_set.count(), 1)
 
     def test_delete_answer(self):
         staff = UserFactory(is_staff=True)
@@ -90,23 +90,23 @@ class TestQuizViews(TestCase):
 
         # are you sure view
         response = delete_answer(request, self.correct.id)
-        self.assertEquals(self.question1.answer_set.count(), 2)
+        self.assertEqual(self.question1.answer_set.count(), 2)
         self.assertContains(response, 'Are you sure')
 
         # delete
         request = RequestFactory().post('/')
         request.user = staff
         response = delete_answer(request, self.correct.id)
-        self.assertEquals(response.status_code, 302)
-        self.assertEquals(self.question1.answer_set.count(), 1)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(self.question1.answer_set.count(), 1)
 
     def test_reorder_answers(self):
         url = reverse('reorder-answer', args=[self.question1.id])
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
-        self.assertEquals(self.correct.ordinality, 1)
-        self.assertEquals(self.incorrect.ordinality, 2)
+        self.assertEqual(self.correct.ordinality, 1)
+        self.assertEqual(self.incorrect.ordinality, 2)
 
         url = '/?answer_0={}&answer_1={}'.format(
             self.incorrect.id, self.correct.id)
@@ -114,20 +114,20 @@ class TestQuizViews(TestCase):
         request.user = UserFactory(is_staff=True)
 
         response = reorder_answers(request, self.question1.id)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         self.correct.refresh_from_db()
-        self.assertEquals(self.correct.ordinality, 2)
+        self.assertEqual(self.correct.ordinality, 2)
         self.incorrect.refresh_from_db()
-        self.assertEquals(self.incorrect.ordinality, 1)
+        self.assertEqual(self.incorrect.ordinality, 1)
 
     def test_reorder_questions(self):
         url = reverse('reorder-questions', args=[self.quiz.id])
         response = self.client.get(url)
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
 
-        self.assertEquals(self.question1.ordinality, 1)
-        self.assertEquals(self.question2.ordinality, 2)
+        self.assertEqual(self.question1.ordinality, 1)
+        self.assertEqual(self.question2.ordinality, 2)
 
         url = '/?question_0={}&question_1={}'.format(
             self.question2.id, self.question1.id)
@@ -135,12 +135,12 @@ class TestQuizViews(TestCase):
         request.user = UserFactory(is_staff=True)
 
         response = reorder_questions(request, self.quiz.id)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
         self.question1.refresh_from_db()
-        self.assertEquals(self.question1.ordinality, 2)
+        self.assertEqual(self.question1.ordinality, 2)
         self.question2.refresh_from_db()
-        self.assertEquals(self.question2.ordinality, 1)
+        self.assertEqual(self.question2.ordinality, 1)
 
     def test_add_question_to_quiz(self):
         data = {u'text': [u'the text'],
@@ -151,8 +151,8 @@ class TestQuizViews(TestCase):
         request.user = UserFactory(is_staff=True)
         response = add_question_to_quiz(request, self.quiz.id)
 
-        self.assertEquals(response.status_code, 302)
-        self.assertEquals(self.quiz.question_set.count(), 3)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(self.quiz.question_set.count(), 3)
 
     def test_edit_question(self):
         request = RequestFactory().get('/')
@@ -174,8 +174,8 @@ class TestQuizViews(TestCase):
         request.user = UserFactory(is_staff=True)
         response = add_answer_to_question(request, self.question1.id)
 
-        self.assertEquals(response.status_code, 302)
-        self.assertEquals(self.question1.answer_set.count(), 3)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(self.question1.answer_set.count(), 3)
 
     def test_load_state(self):
         u = UserFactory()
@@ -194,12 +194,12 @@ class TestQuizViews(TestCase):
 
         data = {'json': dumps(self.json_state)}
         response = self.client.post('/activity/quiz/save/', data)
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
-        self.assertEquals(loads(response.content)['success'], 1)
+        self.assertEqual(loads(response.content)['success'], 1)
 
         n = ActivityState.objects.filter(user=u, json=data['json']).count()
-        self.assertEquals(n, 1)
+        self.assertEqual(n, 1)
 
     def test_save_state_updated(self):
         # when no state exists
@@ -209,7 +209,7 @@ class TestQuizViews(TestCase):
 
         data = {'json': '{}'}
         response = self.client.post('/activity/quiz/save/', data)
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(loads(response.content)['success'], 1)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(loads(response.content)['success'], 1)
         n = ActivityState.objects.filter(user=u, json='{}').count()
-        self.assertEquals(n, 1)
+        self.assertEqual(n, 1)


### PR DESCRIPTION
assertEquals has long since been deprecated, and we can do this change independently of the django update, which is still in progress on a different branch.